### PR TITLE
feat: Add optional due dates and sorting to Todos

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,6 +76,7 @@ fn initialize_database(app_handle: &impl Manager<tauri::Wry>) -> Result<Connecti
 
 #[tauri::command]
 fn add_todo(app_handle: tauri::AppHandle, task: String, due_date: Option<String>) -> Result<(), String> {
+    println!("[Rust] add_todo called with task: '{}', due_date: {:?}", task, due_date); // Added this line
     let conn = get_db_connection(&app_handle)?;
     conn.execute(
         "INSERT INTO todos (task, completed, due_date) VALUES (?1, 0, ?2)",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,7 +40,6 @@ fn initialize_database(app_handle: &impl Manager<tauri::Wry>) -> Result<Connecti
     let db_path = app_data_path.join("todo.db");
     let conn = Connection::open(db_path)?;
 
-    // Ensure the table exists, including the due_date column for new databases.
     conn.execute(
         "CREATE TABLE IF NOT EXISTS todos (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -51,23 +50,23 @@ fn initialize_database(app_handle: &impl Manager<tauri::Wry>) -> Result<Connecti
         [],
     )?;
 
-    // Check if 'due_date' column actually exists (for older databases that might not have it)
-    let mut stmt = conn.prepare("PRAGMA table_info(todos);")?;
-    let mut column_exists = false;
-    // Iterate over column names from PRAGMA table_info(todos)
-    let column_names = stmt.query_map([], |row| row.get::<_, String>("name"))?;
-
-    for name_result in column_names {
-        if let Ok(name) = name_result {
-            if name == "due_date" {
-                column_exists = true;
-                break;
+    // Determine column_exists within a scope, then use it.
+    let mut column_exists_flag = false;
+    {
+        let mut stmt = conn.prepare("PRAGMA table_info(todos);")?;
+        let column_names_iter = stmt.query_map([], |row| row.get::<_, String>("name"))?;
+        for name_result in column_names_iter {
+            if let Ok(name) = name_result {
+                if name == "due_date" {
+                    column_exists_flag = true;
+                    break;
+                }
             }
         }
+        // stmt and column_names_iter go out of scope here
     }
 
-    // If 'due_date' column doesn't exist after CREATE TABLE (e.g. table pre-existed without it), add it.
-    if !column_exists {
+    if !column_exists_flag {
         conn.execute("ALTER TABLE todos ADD COLUMN due_date TEXT NULL", [])?;
         println!("'due_date' column successfully added to existing 'todos' table.");
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,13 +74,20 @@ fn initialize_database(app_handle: &impl Manager<tauri::Wry>) -> Result<Connecti
     Ok(conn)
 }
 
+// Add this struct definition
+#[derive(serde::Deserialize)]
+struct AddTodoArgs {
+    task: String,
+    due_date: Option<String>,
+}
+
 #[tauri::command]
-fn add_todo(app_handle: tauri::AppHandle, task: String, due_date: Option<String>) -> Result<(), String> {
-    println!("[Rust] add_todo called with task: '{}', due_date: {:?}", task, due_date); // Added this line
+fn add_todo(app_handle: tauri::AppHandle, args: AddTodoArgs) -> Result<(), String> {
+    println!("[Rust] add_todo called with task: '{}', due_date: {:?}", args.task, args.due_date);
     let conn = get_db_connection(&app_handle)?;
     conn.execute(
         "INSERT INTO todos (task, completed, due_date) VALUES (?1, 0, ?2)",
-        params![task, due_date],
+        params![args.task, args.due_date], // Use fields from args struct
     )
     .map_err(|e| format!("Failed to add todo: {}", e))?;
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ struct Todo {
     id: i64,
     task: String,
     completed: bool,
+    due_date: Option<String>, // Added
 }
 
 // Helper function to get database connection
@@ -42,7 +43,8 @@ fn initialize_database(app_handle: &impl Manager<tauri::Wry>) -> Result<Connecti
         "CREATE TABLE IF NOT EXISTS todos (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             task TEXT NOT NULL,
-            completed BOOLEAN NOT NULL DEFAULT 0
+            completed BOOLEAN NOT NULL DEFAULT 0,
+            due_date TEXT NULL -- Added
         )",
         [],
     )?;
@@ -50,11 +52,11 @@ fn initialize_database(app_handle: &impl Manager<tauri::Wry>) -> Result<Connecti
 }
 
 #[tauri::command]
-fn add_todo(app_handle: tauri::AppHandle, task: String) -> Result<(), String> {
+fn add_todo(app_handle: tauri::AppHandle, task: String, due_date: Option<String>) -> Result<(), String> {
     let conn = get_db_connection(&app_handle)?;
     conn.execute(
-        "INSERT INTO todos (task, completed) VALUES (?1, 0)",
-        params![task],
+        "INSERT INTO todos (task, completed, due_date) VALUES (?1, 0, ?2)",
+        params![task, due_date],
     )
     .map_err(|e| format!("Failed to add todo: {}", e))?;
     Ok(())
@@ -63,13 +65,14 @@ fn add_todo(app_handle: tauri::AppHandle, task: String) -> Result<(), String> {
 #[tauri::command]
 fn get_todos(app_handle: tauri::AppHandle) -> Result<Vec<Todo>, String> {
     let conn = get_db_connection(&app_handle)?;
-    let mut stmt = conn.prepare("SELECT id, task, completed FROM todos")
+    let mut stmt = conn.prepare("SELECT id, task, completed, due_date FROM todos")
         .map_err(|e| format!("Failed to prepare statement: {}", e))?;
     let todo_iter = stmt.query_map([], |row| {
         Ok(Todo {
             id: row.get(0)?,
             task: row.get(1)?,
             completed: row.get(2)?,
+            due_date: row.get(3)?, // Added
         })
     })
     .map_err(|e| format!("Failed to query todos: {}", e))?;
@@ -125,4 +128,115 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    // Note: tauri::test::mock_app() might require tauri's "test" feature.
+    // If AppHandle dependent tests are problematic, focus is on direct DB logic.
+
+    #[test]
+    fn test_database_schema() -> std::result::Result<(), String> {
+        let conn = Connection::open_in_memory().map_err(|e| e.to_string())?;
+        // Manually apply schema similar to initialize_database
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS todos (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task TEXT NOT NULL,
+                completed BOOLEAN NOT NULL DEFAULT 0,
+                due_date TEXT NULL
+            )",
+            [],
+        ).map_err(|e| e.to_string())?;
+
+        let mut stmt = conn.prepare("PRAGMA table_info(todos);").map_err(|e| e.to_string())?;
+
+        // Iterate over rows to find the 'due_date' column and check its properties
+        let mut found_due_date_column = false;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>("name")?,
+                row.get::<_, String>("type")?,
+                row.get::<_, i32>("notnull")?, // notnull is 0 for false, 1 for true
+                row.get::<_, Option<String>>("dflt_value")?, // default value
+                row.get::<_, i32>("pk")? // primary key flag
+            ))
+        }).map_err(|e| e.to_string())?;
+
+        for row_result in rows {
+            let (name, type_name, notnull_val, _dflt_value, _pk) = row_result.map_err(|e| e.to_string())?;
+            if name == "due_date" {
+                found_due_date_column = true;
+                assert_eq!(type_name, "TEXT", "due_date column type should be TEXT");
+                assert_eq!(notnull_val, 0, "due_date column should be nullable (NOT NULL constraint is 0)");
+                break;
+            }
+        }
+        assert!(found_due_date_column, "due_date column not found in schema");
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_and_get_todos_with_due_date() -> std::result::Result<(), String> {
+        // This test focuses on the SQL logic for adding and retrieving todos with due_dates,
+        // using an in-memory database directly. It bypasses AppHandle complexities.
+        let conn = Connection::open_in_memory().map_err(|e| format!("In-memory DB error: {}", e))?;
+
+        // Manually create the schema
+        conn.execute(
+            "CREATE TABLE todos (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task TEXT NOT NULL,
+                completed BOOLEAN NOT NULL DEFAULT 0,
+                due_date TEXT NULL
+            )",
+            [],
+        ).map_err(|e| format!("Schema creation error: {}", e))?;
+
+        // Test adding a todo with a due date
+        let task1 = "Todo with due date".to_string();
+        let due_date1 = Some("2023-12-31T10:00:00".to_string()); // Using a more standard ISO format
+        conn.execute(
+            "INSERT INTO todos (task, completed, due_date) VALUES (?1, 0, ?2)",
+            params![task1, due_date1],
+        ).map_err(|e| format!("Insert 1 error: {}", e))?;
+
+        // Test adding a todo without a due date
+        let task2 = "Todo without due date".to_string();
+        let due_date2: Option<String> = None;
+        conn.execute(
+            "INSERT INTO todos (task, completed, due_date) VALUES (?1, 0, ?2)",
+            params![task2, due_date2],
+        ).map_err(|e| format!("Insert 2 error: {}", e))?;
+
+        // Test retrieving todos
+        let mut stmt = conn.prepare("SELECT id, task, completed, due_date FROM todos ORDER BY id ASC")
+            .map_err(|e| format!("Prepare select error: {}", e))?;
+
+        let todos_iter = stmt.query_map([], |row| {
+            Ok(Todo { // Todo struct from the outer scope
+                id: row.get(0)?,
+                task: row.get(1)?,
+                completed: row.get(2)?,
+                due_date: row.get(3)?,
+            })
+        }).map_err(|e| format!("Query map error: {}", e))?;
+
+        let mut results = Vec::new();
+        for todo_result in todos_iter {
+            results.push(todo_result.map_err(|e| format!("Row processing error: {}", e))?);
+        }
+
+        assert_eq!(results.len(), 2, "Should retrieve two todos");
+
+        assert_eq!(results[0].task, task1, "Task 1 name mismatch");
+        assert_eq!(results[0].due_date, due_date1, "Task 1 due_date mismatch");
+
+        assert_eq!(results[1].task, task2, "Task 2 name mismatch");
+        assert_eq!(results[1].due_date, due_date2, "Task 2 due_date mismatch");
+
+        Ok(())
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,7 +83,6 @@ struct AddTodoArgs {
 
 #[tauri::command]
 fn add_todo(app_handle: tauri::AppHandle, args: AddTodoArgs) -> Result<(), String> {
-    println!("[Rust] add_todo called with task: '{}', due_date: {:?}", args.task, args.due_date);
     let conn = get_db_connection(&app_handle)?;
     conn.execute(
         "INSERT INTO todos (task, completed, due_date) VALUES (?1, 0, ?2)",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,11 +4,12 @@ use tauri::Manager;
 
 // Define Todo struct
 #[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")] // Added this line
 struct Todo {
     id: i64,
     task: String,
     completed: bool,
-    due_date: Option<String>, // Added
+    due_date: Option<String>, // This field will be serialized as 'dueDate'
 }
 
 // Helper function to get database connection

--- a/src/lib/stores/todoStore.test.ts
+++ b/src/lib/stores/todoStore.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { writable } from 'svelte/store';
+import { addTodo, todos, type Todo } from './todoStore';
+
+let mockInvokeImplementation: (...args: any[]) => Promise<any> = async () => {};
+
+vi.mock('@tauri-apps/api/core', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    invoke: (...args: any[]) => mockInvokeImplementation(...args),
+  };
+});
+
+beforeEach(() => {
+  todos.set([]);
+  mockInvokeImplementation = async (command: string, args?: any) => {
+    if (command === 'get_todos') {
+      return [];
+    }
+    return undefined;
+  };
+  vi.clearAllMocks();
+});
+
+describe('todoStore', () => {
+  describe('addTodo', () => {
+    it('should call invoke with "add_todo" and correct parameters including dueDate', async () => {
+      const taskText = 'Test new todo';
+      const dueDate = '2024-01-01T10:00';
+
+      const localMockInvoke = vi.fn().mockImplementation(mockInvokeImplementation);
+      mockInvokeImplementation = localMockInvoke;
+
+      await addTodo(taskText, dueDate);
+
+      expect(localMockInvoke).toHaveBeenCalledWith('add_todo', {
+        task: taskText,
+        dueDate: dueDate,
+      });
+    });
+
+    it('should call invoke with "add_todo" and null for dueDate if not provided', async () => {
+      const taskText = 'Test todo without due date';
+
+      const localMockInvoke = vi.fn().mockImplementation(mockInvokeImplementation);
+      mockInvokeImplementation = localMockInvoke;
+
+      await addTodo(taskText, null);
+
+      expect(localMockInvoke).toHaveBeenCalledWith('add_todo', {
+        task: taskText,
+        dueDate: null,
+      });
+    });
+
+    it('should call loadTodos (which invokes "get_todos") after successfully adding a todo', async () => {
+      const taskText = 'Another todo';
+      const mockTodosAfterAdd: Todo[] = [{ id: 1, task: taskText, completed: false, dueDate: null }];
+
+      const localMockInvoke = vi.fn().mockImplementation(async (command: string, args?: any) => {
+        if (command === 'add_todo') {
+          return undefined;
+        }
+        if (command === 'get_todos') {
+          return mockTodosAfterAdd;
+        }
+      });
+      mockInvokeImplementation = localMockInvoke;
+
+      await addTodo(taskText, null);
+
+      expect(localMockInvoke).toHaveBeenCalledWith('add_todo', { task: taskText, dueDate: null });
+      expect(localMockInvoke).toHaveBeenCalledWith('get_todos');
+
+      let currentTodos: Todo[] = [];
+      const unsubscribe = todos.subscribe(value => { currentTodos = value; });
+      expect(currentTodos).toEqual(mockTodosAfterAdd);
+      unsubscribe();
+    });
+
+    it('should not call invoke for "add_todo" if taskText is empty', async () => {
+      const localMockInvoke = vi.fn().mockImplementation(mockInvokeImplementation);
+      mockInvokeImplementation = localMockInvoke;
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await addTodo('', null);
+
+      expect(localMockInvoke).not.toHaveBeenCalledWith('add_todo', expect.anything());
+      expect(consoleErrorSpy).toHaveBeenCalledWith("Task cannot be empty");
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should not call invoke for "add_todo" if taskText is only whitespace', async () => {
+      const localMockInvoke = vi.fn().mockImplementation(mockInvokeImplementation);
+      mockInvokeImplementation = localMockInvoke;
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await addTodo('   ', null);
+
+      expect(localMockInvoke).not.toHaveBeenCalledWith('add_todo', expect.anything());
+      expect(consoleErrorSpy).toHaveBeenCalledWith("Task cannot be empty");
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should log an error and not throw if invoke("add_todo") fails, and not call get_todos', async () => {
+      const taskText = 'Todo that fails to add';
+      const expectedError = new Error('Failed to add');
+
+      const localMockInvoke = vi.fn().mockImplementation(async (command: string, args?: any) => {
+        if (command === 'add_todo') {
+          throw expectedError;
+        }
+      });
+      mockInvokeImplementation = localMockInvoke;
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await addTodo(taskText, null);
+
+      expect(localMockInvoke).toHaveBeenCalledWith('add_todo', { task: taskText, dueDate: null });
+      expect(localMockInvoke).not.toHaveBeenCalledWith('get_todos');
+      expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to add todo:", expectedError);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/src/lib/stores/todoStore.ts
+++ b/src/lib/stores/todoStore.ts
@@ -30,9 +30,6 @@ export async function addTodo(taskText: string, dueDate: string | null): Promise
     return;
   }
   try {
-    // Log parameters as received by this store function
-    console.log(`[todoStore.addTodo] Preparing to invoke 'add_todo'. Task: "${taskText}", DueDate: ${dueDate}`);
-
     // Wrap payload in 'args' to match Rust struct argument
     await invoke('add_todo', { args: { task: taskText, due_date: dueDate } });
     await loadTodos();

--- a/src/lib/stores/todoStore.ts
+++ b/src/lib/stores/todoStore.ts
@@ -6,6 +6,7 @@ export interface Todo {
   id: number; // Assuming id from backend is i64, which maps to number in JS/TS
   task: string;
   completed: boolean;
+  dueDate: string | null;
 }
 
 // Create a writable store for todos with the Todo interface
@@ -23,13 +24,14 @@ export async function loadTodos(): Promise<void> {
 }
 
 // Implement addTodo function with types
-export async function addTodo(taskText: string): Promise<void> {
+export async function addTodo(taskText: string, dueDate: string | null): Promise<void> {
   if (!taskText || taskText.trim() === "") {
     console.error("Task cannot be empty");
     return; // Or throw an error
   }
   try {
-    await invoke('add_todo', { task: taskText });
+    // The backend expects dueDate as part of the object.
+    await invoke('add_todo', { task: taskText, dueDate: dueDate });
     await loadTodos(); // Reload todos to reflect the addition
   } catch (error) {
     console.error("Failed to add todo:", error);

--- a/src/lib/stores/todoStore.ts
+++ b/src/lib/stores/todoStore.ts
@@ -30,8 +30,8 @@ export async function addTodo(taskText: string, dueDate: string | null): Promise
     return; // Or throw an error
   }
   try {
-    // The backend expects dueDate as part of the object.
-    await invoke('add_todo', { task: taskText, dueDate: dueDate });
+    // Align key with Rust backend parameter name 'due_date'
+    await invoke('add_todo', { task: taskText, due_date: dueDate });
     await loadTodos(); // Reload todos to reflect the addition
   } catch (error) {
     console.error("Failed to add todo:", error);

--- a/src/lib/stores/todoStore.ts
+++ b/src/lib/stores/todoStore.ts
@@ -27,12 +27,15 @@ export async function loadTodos(): Promise<void> {
 export async function addTodo(taskText: string, dueDate: string | null): Promise<void> {
   if (!taskText || taskText.trim() === "") {
     console.error("Task cannot be empty");
-    return; // Or throw an error
+    return;
   }
   try {
-    // Align key with Rust backend parameter name 'due_date'
-    await invoke('add_todo', { task: taskText, due_date: dueDate });
-    await loadTodos(); // Reload todos to reflect the addition
+    // Log parameters as received by this store function
+    console.log(`[todoStore.addTodo] Preparing to invoke 'add_todo'. Task: "${taskText}", DueDate: ${dueDate}`);
+
+    // Wrap payload in 'args' to match Rust struct argument
+    await invoke('add_todo', { args: { task: taskText, due_date: dueDate } });
+    await loadTodos();
   } catch (error) {
     console.error("Failed to add todo:", error);
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,8 +13,14 @@
 
   async function handleAddTodo(): Promise<void> {
     if (newTaskText.trim() === '') return;
-    // Pass null if newDueDate is empty, otherwise pass the string value
-    await addTodo(newTaskText, newDueDate || null);
+
+    // Log the values just before using them
+    console.log('[handleAddTodo] Attempting to add todo. Task:', newTaskText, 'Raw newDueDate:', newDueDate);
+
+    const dueDateToSend = newDueDate || null;
+    console.log('[handleAddTodo] Due date to send to store:', dueDateToSend);
+
+    await addTodo(newTaskText, dueDateToSend);
     newTaskText = '';
     newDueDate = ''; // Reset due date input
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,13 +14,7 @@
   async function handleAddTodo(): Promise<void> {
     if (newTaskText.trim() === '') return;
 
-    // Log the values just before using them
-    console.log('[handleAddTodo] Attempting to add todo. Task:', newTaskText, 'Raw newDueDate:', newDueDate);
-
-    const dueDateToSend = newDueDate || null;
-    console.log('[handleAddTodo] Due date to send to store:', dueDateToSend);
-
-    await addTodo(newTaskText, dueDateToSend);
+    await addTodo(newTaskText, newDueDate || null); // Keep the core logic
     newTaskText = '';
     newDueDate = ''; // Reset due date input
   }


### PR DESCRIPTION
This commit introduces the ability to add an optional due date and time to Todo items and sort them accordingly.

Key changes:

- Modified the `Todo` data structure (frontend and backend) to include an optional `dueDate` (or `due_date`) field.
- Updated the SQLite database schema in the Tauri backend to add a nullable `due_date` TEXT column to the `todos` table.
- Enhanced the `add_todo` backend function (Rust) to accept and store the `due_date`.
- Updated the `get_todos` backend function (Rust) to retrieve the `due_date`.
- Modified the `addTodo` frontend store function (TypeScript) to send the `dueDate` to the backend.
- Updated the Svelte UI (`+page.svelte`):
    - Added an `<input type="datetime-local">` for setting the due date when creating a new todo.
    - Due dates are now displayed alongside tasks.
    - Implemented a sort button that toggles sorting by due date.
    - Sorting logic: Tasks without a due date appear first, followed by tasks with due dates sorted chronologically (earliest first).
- Added unit tests:
    - For the Rust backend: testing database schema changes and `add_todo`/`get_todos` logic with `due_date`.
    - For the frontend Svelte store: testing the `addTodo` function's handling of `dueDate` and its interaction with the (mocked) backend.

This addresses the issue requirement to allow setting due dates for tasks and sorting them, with tasks having due dates appearing at the end of the sorted list.